### PR TITLE
Avoid erroneous URLs from being blocked in Drupal

### DIFF
--- a/8G-SetEnvIf
+++ b/8G-SetEnvIf
@@ -98,8 +98,8 @@
 	SetEnvIfNoCase Request_URI /(?:router|savepng|semayan|shell|shootme|sky|socket(?:c|i|iasrgasf)ontrol|sql(?:bak|_?dump)?|support|sym403|sys|system_log|test|tmp-?(?:uploads)?)\.php bot
 	SetEnvIfNoCase Request_URI /(?:traffic-advice|u2p|udd|ukauka|up__uzegp|up14|upa?|upxx?|vega|vip|vu(?:ln)?\w?|webroot|weki|wikindex|wordpress|wp_logns?|wp_wrong_datlib)\.php bot
 	SetEnvIfNoCase Request_URI /(?:wp-?install|installation|wp(?:3|4|5|6)|wpfootes|wpzip|ws0|wsdl|wso\w?|www|(?:uploads|wp-admin)?xleet(?:-shell)?|xmlsrpc|xup|xxu|xxx|zibi|zipy)\.php bot
-	SetEnvIfNoCase Request_URI bkv74|cachedsimilar|core-stab|crgrvnkb|ctivrc|deadcode|deathshop|dkiz|e7xue|eqxafaj90zir|exploits|ffmkpcal|filellli7|(?:fox|sid)wso|gel4y|goog1es|gvqqpinc bot
-	SetEnvIfNoCase Request_URI @md5|00.temp00|0byte|0d4y|0day|0xor|wso1337|1h6j5|3xp|40dd1d|4price|70bex?|a57bze893|abbrevsprl|abruzi|adminer|aqbmkwwx|archivarix|backdoor|beez5|bgvzc29 bot
+	SetEnvIfNoCase Request_URI (?:bkv74|cachedsimilar|core-stab|crgrvnkb|ctivrc|deadcode|deathshop|dkiz|e7xue|eqxafaj90zir|exploits|ffmkpcal|filellli7|(?:fox|sid)wso|gel4y|goog1es|gvqqpinc)(?:[-_.\/]|$) bot
+	SetEnvIfNoCase Request_URI (?:@md5|00.temp00|0byte|0d4y|0day|0xor|wso1337|1h6j5|3xp|40dd1d|4price|70bex?|a57bze893|abbrevsprl|abruzi|adminer|aqbmkwwx|archivarix|backdoor|beez5|bgvzc29)(?:[-_.\/]|$) bot
 	SetEnvIfNoCase Request_URI handler_to_code|hax(?:0|o)r|hmei7|hnap1|home_url=|ibqyiove|icxbsx|indoxploi|jahat|jijle3|kcrew|keywordspy|laobiao|lock360|longdog|marijuan|mod_(?:aratic|ariimag) bot
 	SetEnvIfNoCase Request_URI mobiquo|muiebl|nessus|osbxamip|phpunit|priv8|qcmpecgy|r3vn330|racrew|raiz0|reportserver|r00t|respectmus|rom2823|roseleif|sh3ll|site.{0,2}copier|sqlpatch|sux0r bot
 	SetEnvIfNoCase Request_URI sym403|telerik|uddatasql|utchiha|visualfrontend|w0rm|wangdafa|wpyii2|wsoyanzo|x5cv|xattack|xbaner|xertive|xiaolei|xltavrat|xorz|xsamxad|xsvip|xxxs?s?|zabbix|zebda bot

--- a/8g-firewall.conf
+++ b/8g-firewall.conf
@@ -107,8 +107,8 @@ map $uri $bad_request_ng {
 	"~*/(?:router|savepng|semayan|shell|shootme|sky|socket(?:c|i|iasrgasf)ontrol|sql(?:bak|_?dump)?|support|sym403|sys|system_log|test|tmp-?(?:uploads)?)\.php" 47;
 	"~*/(?:traffic-advice|u2p|udd|ukauka|up__uzegp|up14|upa?|upxx?|vega|vip|vu(?:ln)?\w?|webroot|weki|wikindex|wordpress|wp_logns?|wp_wrong_datlib)\.php" 48;
 	"~*/(?:wp-?install|installation|wp(?:3|4|5|6)|wpfootes|wpzip|ws0|wsdl|wso\w?|www|(?:uploads|wp-admin)?xleet(?:-shell)?|xmlsrpc|xup|xxu|xxx|zibi|zipy)\.php" 49;
-	"~*bkv74|cachedsimilar|core-stab|crgrvnkb|ctivrc|deadcode|deathshop|dkiz|e7xue|eqxafaj90zir|exploits|ffmkpcal|filellli7|(?:fox|sid)wso|gel4y|goog1es|gvqqpinc" 50;
-	"~*@md5|00.temp00|0byte|0d4y|0day|0xor|wso1337|1h6j5|3xp|40dd1d|4price|70bex?|a57bze893|abbrevsprl|abruzi|adminer|aqbmkwwx|archivarix|backdoor|beez5|bgvzc29" 51;
+	"~*(?:bkv74|cachedsimilar|core-stab|crgrvnkb|ctivrc|deadcode|deathshop|dkiz|e7xue|eqxafaj90zir|exploits|ffmkpcal|filellli7|(?:fox|sid)wso|gel4y|goog1es|gvqqpinc)(?:[-_.\/]|$)" 50;
+	"~*(?:@md5|00.temp00|0byte|0d4y|0day|0xor|wso1337|1h6j5|3xp|40dd1d|4price|70bex?|a57bze893|abbrevsprl|abruzi|adminer|aqbmkwwx|archivarix|backdoor|beez5|bgvzc29)(?:[-_.\/]|$)" 51;
 	"~*handler_to_code|hax(?:0|o)r|hmei7|hnap1|home_url=|ibqyiove|icxbsx|indoxploi|jahat|jijle3|kcrew|keywordspy|laobiao|lock360|longdog|marijuan|mod_(?:aratic|ariimag)" 52;
 	"~*mobiquo|muiebl|nessus|osbxamip|phpunit|priv8|qcmpecgy|r3vn330|racrew|raiz0|reportserver|r00t|respectmus|rom2823|roseleif|sh3ll|site.{0,2}copier|sqlpatch|sux0r" 53;
 	"~*sym403|telerik|uddatasql|utchiha|visualfrontend|w0rm|wangdafa|wpyii2|wsoyanzo|x5cv|xattack|xbaner|xertive|xiaolei|xltavrat|xorz|xsamxad|xsvip|xxxs?s?|zabbix|zebda" 54;


### PR DESCRIPTION
e.g. "3xp" is too wide a wildcard as it can block legitimate requests from a Drupal site.

Example legitimate CSS asset that was being blocked because it happened to contain `3xp`:
```
https://example.com/sites/default/files/css/css_arpr4ScoUF2QUJXblNa4BKkO8lunNETe7-ifiFT82CA.css?delta=6&include=eJyNVFly2zAMvZAkfvU8HIiEZdTgMgSYND19IdlsMrWm8Y9IPDxih0AE1VP-iUFLc0HEAbMB_h3XS2lpgmdGqL5hLVnoDb0i270ptlOqgl-5hJucaS8M27mitJ5ONbWVXfJKCZkynnGEtux7vTs-Izxy86HkC7UESiX7hCKwnRoc_AiKu2MvFQLlbTIDir-0A7vYegVePpHZwrO0LwbAO0pJ6L7cl8NmVlmkMMXvaQ23ztC-J64NcpRJSiBgyyoS-CMU9wwtesWElkZDly1DYPptovkpbuOyWhaiH3xPtedA7CuDHsWAmCj_y7LUd8OjGg9xwm61LjdCO1JlghzQnYF-hYbPvo4wXShcepsrhZtNm5YbZnd8pwuxDeDwepcmY0WyFv5wZD1p2TSjSUPzCmehtI_FK8yjsi8xFVbGCbOSfnhMK0b3VbDkClsp3ON8rsjRsqFtuHbi6AOEK3oIwUbZPcD5AOc7OI8XEd_QZnb__sV63efbX5ErNm-Pwo1JdHiZ165asgX9Rq3kZPHalkQKsK_JaPiZcjpGxT_seEFo4erux9Tls3H7fSFbIfn_Zo2I5Wo_ntB1UIb8By_N57M&language=en&theme=custom_theme_name
```

I've proposed a sample update to the logic, but I think it'd be better if pathless matches are a bit more strict as to how they match (e.g. if they're for php scripts, or specific patterns) in case they happen to match legitimate requests.