### PR TITLE
Remove "/usage/" from the blocked URI pattern

### DIFF
--- a/8G-SetEnvIf
+++ b/8G-SetEnvIf
@@ -79,7 +79,7 @@
 	SetEnvIfNoCase Request_URI ^/(?:123|backup|bak|beta|bkp|default|demo|dev(?:new|old)?|new-?site|null|old|old_files|old1)/?$ bot
 	SetEnvIfNoCase Request_URI j\s*a\s*v\s*a\s*s\s*c\s*r\s*i\s*p\s*t\s*(?:%3a|:) bot
 	SetEnvIfNoCase Request_URI ^/(?:old-?site(?:back)?|old(?:web)?site(?:here)?|sites?|staging|undefined|wordpress[0-9]+|wordpress-old)/?$ bot
-	SetEnvIfNoCase Request_URI /(?:filemanager|htdocs|httpdocs|https?|mailman|mailto|msoffice|undefined|usage|var|vhosts|webmaster|www)/ bot
+	SetEnvIfNoCase Request_URI /(?:filemanager|htdocs|httpdocs|https?|mailman|mailto|msoffice|undefined|var|vhosts|webmaster|www)/ bot
 	SetEnvIfNoCase Request_URI \(null\)|\{\$itemURL\}|cast\(0x|echo.*kae|etc/passwd|eval\(|null.*null|open_basedir|self/environ|\+union\+all\+select bot
 	SetEnvIfNoCase Request_URI (?:conf\b|conf(?:ig)?)(?:uration)?(?:\.?bak|\.inc|\.old|\.php|\.txt) bot
 	SetEnvIfNoCase Request_URI /(?:.*crlf-?injection|.*xss-?protection|__(?:inc|jsc)|author-panel|cgi-bin|database|downloader|(?:db|mysql)-?admin)/ bot

--- a/8g-firewall.conf
+++ b/8g-firewall.conf
@@ -88,7 +88,7 @@ map $uri $bad_request_ng {
 	"~*^/(?:123|backup|bak|beta|bkp|default|demo|dev(?:new|old)?|new-?site|null|old|old_files|old1)/?$" 28;
 	"~*j\s*a\s*v\s*a\s*s\s*c\s*r\s*i\s*p\s*t\s*(?:%3a|:)" 29;
 	"~*^/(?:old-?site(?:back)?|old(?:web)?site(?:here)?|sites?|staging|undefined|wordpress[0-9]+|wordpress-old)/?$" 30;
-	"~*/(?:filemanager|htdocs|httpdocs|https?|mailman|mailto|msoffice|undefined|usage|var|vhosts|webmaster|www)/" 31;
+	"~*/(?:filemanager|htdocs|httpdocs|https?|mailman|mailto|msoffice|undefined|var|vhosts|webmaster|www)/" 31;
 	"~*\(null\)|\{\$itemURL\}|cast\(0x|echo.*kae|etc/passwd|eval\(|null.*null|open_basedir|self/environ|\+union\+all\+select" 32;
 	"~*(?:conf\b|conf(?:ig)?)(?:uration)?(?:\.?bak|\.inc|\.old|\.php|\.txt)" 33;
 	"~*/(?:.*crlf-?injection|.*xss-?protection|__(?:inc|jsc)|author-panel|cgi-bin|database|downloader|(?:db|mysql)-?admin)/" 34;


### PR DESCRIPTION
The URI is used in Drupal's [file usage page](https://git.drupalcode.org/project/drupal/-/blob/b25bc52e/core/modules/file/config/optional/views.view.files.yml#L423).

Example URI being blocked: https://nginxdev.com/admin/content/files/usage/123