### PR TITLE
Fix: Prevent false 403s from 8G firewall bad_referer pattern on valid referers

### DIFF
--- a/8G-SetEnvIf
+++ b/8G-SetEnvIf
@@ -134,7 +134,7 @@
 # 8G:[HTTP REFERRER]
 
 	SetEnvIfNoCase Referer order(?:\s|%20)by(?:\s|%20)1-- bot
-	SetEnvIfNoCase Referer @unlink|assert\(|print_r\(|x00|xbshell bot
+	SetEnvIfNoCase Referer @unlink|assert\(|print_r\(|\x00|%00|xbshell bot
 	SetEnvIfNoCase Referer 100dollars|best-seo|blue\spill|cocaine|ejaculat|erectile|erections|hoodia|huronriveracres|impotence|levitra|libido|lipitor|mopub\.com|phentermin bot
 	SetEnvIfNoCase Referer pornhelm|pro[sz]ac|sandyauer|semalt\.com|social-buttions|todaperfeita|tramadol|troyhamby|ultram|unicauca|valium|viagra|vicodin|xanax|ypxaieo bot
 

--- a/8G-SetEnvIf
+++ b/8G-SetEnvIf
@@ -134,7 +134,7 @@
 # 8G:[HTTP REFERRER]
 
 	SetEnvIfNoCase Referer order(?:\s|%20)by(?:\s|%20)1-- bot
-	SetEnvIfNoCase Referer @unlink|assert\(|print_r\(|\x00|%00|xbshell bot
+	SetEnvIfNoCase Referer @unlink|assert\(|print_r\(|\\\x00|%00|xbshell bot
 	SetEnvIfNoCase Referer 100dollars|best-seo|blue\spill|cocaine|ejaculat|erectile|erections|hoodia|huronriveracres|impotence|levitra|libido|lipitor|mopub\.com|phentermin bot
 	SetEnvIfNoCase Referer pornhelm|pro[sz]ac|sandyauer|semalt\.com|social-buttions|todaperfeita|tramadol|troyhamby|ultram|unicauca|valium|viagra|vicodin|xanax|ypxaieo bot
 

--- a/8g-firewall.conf
+++ b/8g-firewall.conf
@@ -144,7 +144,7 @@ map $http_referer $bad_referer_ng {
 	default 0;
 	
 	"~*order(?:\s|%20)by(?:\s|%20)1--" 1;
-	"~*@unlink|assert\(|print_r\(|\\x00|xbshell" 2;
+	"~*@unlink|assert\(|print_r\(|\\x00|%00|xbshell" 2;
 	"~*100dollars|best-seo|blue\spill|cocaine|ejaculat|erectile|erections|hoodia|huronriveracres|impotence|levitra|libido|lipitor|mopub\.com|phentermin" 3;
 	"~*pornhelm|pro[sz]ac|sandyauer|semalt\.com|social-buttions|todaperfeita|tramadol|troyhamby|ultram|unicauca|valium|viagra|vicodin|xanax|ypxaieo" 4;
 	

--- a/8g-firewall.conf
+++ b/8g-firewall.conf
@@ -144,7 +144,7 @@ map $http_referer $bad_referer_ng {
 	default 0;
 	
 	"~*order(?:\s|%20)by(?:\s|%20)1--" 1;
-	"~*@unlink|assert\(|print_r\(|x00|xbshell" 2;
+	"~*@unlink|assert\(|print_r\(|\\x00|xbshell" 2;
 	"~*100dollars|best-seo|blue\spill|cocaine|ejaculat|erectile|erections|hoodia|huronriveracres|impotence|levitra|libido|lipitor|mopub\.com|phentermin" 3;
 	"~*pornhelm|pro[sz]ac|sandyauer|semalt\.com|social-buttions|todaperfeita|tramadol|troyhamby|ultram|unicauca|valium|viagra|vicodin|xanax|ypxaieo" 4;
 	


### PR DESCRIPTION
### Summary

This PR addresses a bug in the 8G firewall ruleset where valid frontend and admin requests were being blocked with 403 Forbidden responses. The root cause was an overly broad regex pattern in `$bad_referer_ng` that incorrectly matched strings like `BASEBOX007APEX2025` due to the use of `x00`.

### What was changed

- Refined the regex pattern `"x00"` in the `$bad_referer_ng` map to match only the actual null byte escape sequence `\x00`.
- Preserved other malicious pattern detections in the same block.
- Verified the change resolves blocked requests to `/product/TESTX007TEST` and similar URLs.